### PR TITLE
Add initial template for contributing and issue template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# How to become a contributor and submit your own code
+
+## Contributing A Patch
+
+1. Submit an issue describing your proposed change to the repo in question.
+1. The repo owner will respond to your issue promptly.
+1. Fork the desired repo, develop and test your code changes.
+1. Ensure that your code adheres to the existing style in the sample to which
+   you are contributing. Refer to the
+   [Android Code Style Guide]
+   (https://source.android.com/source/code-style.html) for the
+   recommended coding standards for this organization.
+1. Ensure that your code has an appropriate set of unit tests which all pass.
+1. Submit a pull request.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+### Summary
+
+Try to describe your issue in details.
+
+### Stock-Hawk Version
+
+
+
+### Android Version (19, 26, etc.)
+
+
+
+### Expected Behavior
+
+Please describe the expected behavior of the issue, starting from the first action.
+
+1.
+2.
+3.
+
+### Actual Behavior
+
+Please provide a description of what actually happens, working from the same starting point.
+
+Be descriptive: "it doesn't work" does not describe what the behavior actually is.
+
+1.
+2.
+3.
+
+### Reproducible Test Case
+
+If the issue is more complex or requires configuration, please provide a link to a project on Github that reproduces the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Please make sure these boxes are checked before submitting your pull request - thanks!
+
+Fixes #{Issue Number}
+
+- [ ] Follow the style used in this project.
+
+- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything
+
+- [ ] If you have multiple commits please combine them into one commit by squashing them.


### PR DESCRIPTION
Initial drop for [issues/24](https://github.com/therajanmaurya/Stock-Hawk/issues/24).

Because I am not vary familiar with this project there are some thing to improve.  
For example:

- Should we add a placeholder for logs?
- Should reporter specify any additional environment details?